### PR TITLE
feat(notifications): add surplus deal notification trigger for TC-019

### DIFF
--- a/services/platform-service/products/views.py
+++ b/services/platform-service/products/views.py
@@ -57,6 +57,43 @@ class ProductDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
     permission_classes = [IsProducerOrReadOnly]
+    
+    def perform_update(self, serializer):
+        product_before = self.get_object()
+        from orders.models import SurplusDeal
+        from django.utils import timezone
+        was_surplus_before = SurplusDeal.objects.filter(
+            product=product_before,
+            expiry_date__gt=timezone.now()
+        ).exists()
+        product = serializer.save()
+
+        # Notify customers if product just became a surplus deal (TC-019)
+        if not was_surplus_before and product.is_surplus:
+            import requests as http_requests
+            import os
+            from orders.models import Order
+
+            NOTIFICATIONS_API_URL = os.environ.get('NOTIFICATIONS_API_URL', 'http://notifications-api:8001')
+            # Find all unique customers who have ordered from this producer
+            customer_ids = Order.objects.filter(
+                producer=product.producer
+            ).values_list('customer_id', flat=True).distinct()
+
+            for customer_id in customer_ids:
+                try:
+                    http_requests.post(
+                        f"{NOTIFICATIONS_API_URL}/api/notifications/",
+                        headers={'X-Service-Secret': os.environ.get('JWT_SECRET_KEY', '')},
+                        json={
+                            'user': customer_id,
+                            'message': f"Surplus Deal: {product.name} from {product.producer.username} is now available at a discount!",
+                            'type': 'SURPLUS_DEAL'
+                        },
+                        timeout=5
+                    )
+                except Exception:
+                    pass
 
 class CategoryDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Category.objects.all()


### PR DESCRIPTION
--Superseded by #119 which includes the complete notification system implementation. This PR can be closed down.--



## Description
This PR implements TC-019 — surplus deal notifications for customers. When a producer 
marks a product as a surplus deal, all customers who have previously ordered from that 
producer receive a `SURPLUS_DEAL` notification automatically.

## Changes

### platform-service/products/views.py
- Added `perform_update` override to `ProductDetailView`
- Before saving, checks if the product had an active surplus deal using a direct 
  database query to avoid cached property issues
- After saving, if the product just became a surplus deal (was not surplus before, 
  is surplus now), finds all unique customers who have previously ordered from that 
  producer via `Order.objects.filter(producer=product.producer)`
- Sends a `SURPLUS_DEAL` notification to each customer via the notifications-api
- Failure is non-critical and never blocks the product update

## How to Test

**Restart services after pulling:**
```bash
docker-compose restart platform-api
```

**1. Mark a product as surplus (as a producer):**
Method: PATCH

URL:    http://localhost:8002/api/products/<product_id>/
Headers: Authorization: Bearer <producer_token>
Body:
{
"is_surplus": "true",
"surplus_deal.discount_percentage": "30",
"surplus_deal.expiry_date": "2026-04-30T00:00:00Z",
"surplus_deal.deal_note": "Must sell quickly!"
}

**2. Verify customers who have previously ordered from that producer received a notification:**

Method: GET
URL:    http://localhost:8001/api/notifications/list/?recipient_id=<customer_id>
Expected: SURPLUS_DEAL notification with message:
"Surplus Deal: <product_name> from <producer_username> is now available at a discount!"

## Related Issues
Closes #103 