### PR TITLE
Feat/commission logic

### DIFF
--- a/services/frontend-service/frontend/urls.py
+++ b/services/frontend-service/frontend/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     # Profile, admin and producer
     path('profile/', views.profile_view, name='profile'),
     path('admin-dashboard/', views.admin_dashboard, name='admin-dashboard'),
+    path('admin-dashboard/commission/export/', views.admin_commission_export, name='admin-commission-export'),
     path('admin-dashboard/users/<int:user_id>/delete/', views.admin_delete_user, name='admin-delete-user'),
     path('admin-dashboard/users/<int:user_id>/edit/', views.admin_edit_user, name='admin-edit-user'),
     path('admin-dashboard/products/<int:product_id>/delete/', views.admin_delete_product, name='admin-delete-product'),

--- a/services/frontend-service/web/templates/web/admin.html
+++ b/services/frontend-service/web/templates/web/admin.html
@@ -134,6 +134,37 @@
 .commission-summary-row:last-child { border-bottom: none; }
 .commission-highlight { color: var(--green); font-weight: 700; }
 
+.commission-period-summary {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin: 1rem 0 1.5rem;
+}
+.period-stat {
+    flex: 1;
+    min-width: 140px;
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+}
+.period-stat-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin-bottom: 0.3rem;
+}
+.period-stat-value {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--text);
+}
+.commission-period-summary .commission-highlight .period-stat-value {
+    color: var(--green);
+}
+
 .sortable { cursor: pointer; user-select: none; white-space: nowrap; }
 .sort-icon { font-size: 0.7rem; opacity: 0.5; margin-left: 3px; }
 .tab-btn {
@@ -684,15 +715,61 @@
     <div id="tab-commission" class="tab-panel">
         <div class="search-bar" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center;">
             <input class="search-input" style="flex:1;min-width:200px;" type="text" id="commission-search" placeholder="Search by producer…" oninput="filterCommissionTable()">
+            <select class="date-filter-input" id="commission-status" onchange="filterCommission()" style="padding:0.35rem 0.6rem;">
+                <option value="">All Statuses</option>
+                <option value="PENDING">Pending</option>
+                <option value="CONFIRMED">Confirmed</option>
+                <option value="READY">Ready</option>
+                <option value="DELIVERED">Delivered</option>
+            </select>
             <input type="date" class="date-filter-input" id="commission-date-from" onchange="filterCommission()">
             <input type="date" class="date-filter-input" id="commission-date-to" onchange="filterCommission()">
             <div class="date-filter-presets" style="display:flex;gap:0.4rem;">
                 <button type="button" class="date-preset-btn active" onclick="setCommissionPreset('all')">All</button>
-                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('today')">Today</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('ytd')">YTD</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('month')">This Month</button>
                 <button type="button" class="date-preset-btn" onclick="setCommissionPreset('week')">7 Days</button>
-                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('month')">30 Days</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('today')">Today</button>
+            </div>
+            <button type="button" class="date-filter-submit" onclick="exportCommissionCSV()" style="white-space:nowrap;">⬇ Export CSV</button>
+        </div>
+
+        <!-- Period Summary -->
+        <div class="commission-period-summary" id="commission-period-summary">
+            <div class="period-stat">
+                <div class="period-stat-label">Orders in Period</div>
+                <div class="period-stat-value" id="period-orders">—</div>
+            </div>
+            <div class="period-stat">
+                <div class="period-stat-label">Total Revenue</div>
+                <div class="period-stat-value" id="period-revenue">—</div>
+            </div>
+            <div class="period-stat commission-highlight">
+                <div class="period-stat-label">Commission (5%)</div>
+                <div class="period-stat-value" id="period-commission">—</div>
+            </div>
+            <div class="period-stat">
+                <div class="period-stat-label">Producer Payouts (95%)</div>
+                <div class="period-stat-value" id="period-payout">—</div>
             </div>
         </div>
+
+        <!-- Monthly Summary -->
+        <h3 style="font-family:'Cormorant Garamond',serif;font-size:1.2rem;margin:1.5rem 0 0.75rem;">Monthly Summary</h3>
+        <table class="data-table" id="monthly-table" style="margin-bottom:2rem;">
+            <thead>
+                <tr>
+                    <th>Month</th>
+                    <th>Orders</th>
+                    <th>Total Revenue</th>
+                    <th>Commission (5%)</th>
+                    <th>Producer Payouts</th>
+                </tr>
+            </thead>
+            <tbody id="monthly-tbody">
+                <tr class="empty-row"><td colspan="5">Loading…</td></tr>
+            </tbody>
+        </table>
 
         <h3 style="font-family:'Cormorant Garamond',serif;font-size:1.2rem;margin:1.5rem 0 0.75rem;">Per-Producer Breakdown</h3>
         <table class="data-table" id="commission-table">
@@ -874,34 +951,69 @@ function filterCommissionTable() {
 function filterCommission() {
     const dateFrom = document.getElementById('commission-date-from').value;
     const dateTo = document.getElementById('commission-date-to').value;
+    const statusFilter = (document.getElementById('commission-status').value || '').toUpperCase();
 
-    // Filter orders table rows to calculate totals
     const allRows = document.querySelectorAll('#orders-table tbody tr:not(.empty-row)');
-    let revenue = 0, commission = 0;
+    let revenue = 0, commission = 0, orderCount = 0;
     const producerTotals = {};
+    const monthlyTotals = {};
 
     allRows.forEach(row => {
         const rowDate = row.getAttribute('data-date') || '';
+        const cells = row.querySelectorAll('td');
+        const rowStatus = cells[5].textContent.trim().toUpperCase();
         const fromMatch = !dateFrom || rowDate >= dateFrom;
         const toMatch = !dateTo || rowDate <= dateTo;
-        if (fromMatch && toMatch) {
-            const cells = row.querySelectorAll('td');
+        const statusMatch = !statusFilter || rowStatus.includes(statusFilter);
+
+        if (fromMatch && toMatch && statusMatch) {
             const r = parseFloat((cells[3].textContent || '0').replace('£', '')) || 0;
             const c = parseFloat((cells[4].textContent || '0').replace('£', '')) || 0;
             const producer = cells[2].textContent.trim();
+            const month = rowDate.slice(0, 7); // YYYY-MM
             revenue += r;
             commission += c;
+            orderCount++;
+
+            // Producer totals
             if (!producerTotals[producer]) producerTotals[producer] = { orders: 0, revenue: 0, commission: 0 };
             producerTotals[producer].orders++;
             producerTotals[producer].revenue += r;
             producerTotals[producer].commission += c;
+
+            // Monthly totals
+            if (!monthlyTotals[month]) monthlyTotals[month] = { orders: 0, revenue: 0, commission: 0 };
+            monthlyTotals[month].orders++;
+            monthlyTotals[month].revenue += r;
+            monthlyTotals[month].commission += c;
         }
     });
 
-    // Update summary stats in the stat cards
-    document.getElementById('summary-revenue') && (document.getElementById('summary-revenue').textContent = '£' + revenue.toFixed(2));
-    document.getElementById('summary-commission') && (document.getElementById('summary-commission').textContent = '£' + commission.toFixed(2));
-    document.getElementById('summary-payout') && (document.getElementById('summary-payout').textContent = '£' + (revenue - commission).toFixed(2));
+    // Update period summary cards
+    document.getElementById('period-orders').textContent = orderCount;
+    document.getElementById('period-revenue').textContent = '£' + revenue.toFixed(2);
+    document.getElementById('period-commission').textContent = '£' + commission.toFixed(2);
+    document.getElementById('period-payout').textContent = '£' + (revenue - commission).toFixed(2);
+
+    // Rebuild monthly summary table
+    const monthlyTbody = document.getElementById('monthly-tbody');
+    monthlyTbody.innerHTML = '';
+    const months = Object.keys(monthlyTotals).sort().reverse();
+    if (months.length === 0) {
+        monthlyTbody.innerHTML = '<tr class="empty-row"><td colspan="5">No data for this period.</td></tr>';
+    } else {
+        months.forEach(month => {
+            const d = monthlyTotals[month];
+            const label = new Date(month + '-01').toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+            monthlyTbody.innerHTML += `<tr>
+                <td><strong>${label}</strong></td>
+                <td>${d.orders}</td>
+                <td>£${d.revenue.toFixed(2)}</td>
+                <td>£${d.commission.toFixed(2)}</td>
+                <td>£${(d.revenue - d.commission).toFixed(2)}</td>
+            </tr>`;
+        });
+    }
 
     // Rebuild producer breakdown table
     const tbody = document.getElementById('commission-tbody');
@@ -924,7 +1036,8 @@ function filterCommission() {
 }
 
 function setCommissionPreset(preset) {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
     const fromInput = document.getElementById('commission-date-from');
     const toInput = document.getElementById('commission-date-to');
     document.querySelectorAll('#tab-commission .date-preset-btn').forEach(b => b.classList.remove('active'));
@@ -933,18 +1046,31 @@ function setCommissionPreset(preset) {
         fromInput.value = '';
         toInput.value = '';
     } else if (preset === 'today') {
-        fromInput.value = today;
-        toInput.value = today;
+        fromInput.value = todayStr;
+        toInput.value = todayStr;
     } else if (preset === 'week') {
         const d = new Date(); d.setDate(d.getDate() - 7);
         fromInput.value = d.toISOString().slice(0, 10);
-        toInput.value = today;
+        toInput.value = todayStr;
     } else if (preset === 'month') {
-        const d = new Date(); d.setDate(d.getDate() - 30);
-        fromInput.value = d.toISOString().slice(0, 10);
-        toInput.value = today;
+        fromInput.value = todayStr.slice(0, 7) + '-01';
+        toInput.value = todayStr;
+    } else if (preset === 'ytd') {
+        fromInput.value = todayStr.slice(0, 4) + '-01-01';
+        toInput.value = todayStr;
     }
     filterCommission();
+}
+
+function exportCommissionCSV() {
+    const dateFrom = document.getElementById('commission-date-from').value;
+    const dateTo = document.getElementById('commission-date-to').value;
+    let url = '/admin-dashboard/commission/export/';
+    const params = [];
+    if (dateFrom) params.push('date_from=' + dateFrom);
+    if (dateTo) params.push('date_to=' + dateTo);
+    if (params.length) url += '?' + params.join('&');
+    window.location.href = url;
 }
 
 // ── SORTING ──

--- a/services/frontend-service/web/templates/web/admin.html
+++ b/services/frontend-service/web/templates/web/admin.html
@@ -53,6 +53,89 @@
     border-bottom: 2px solid var(--border);
     margin-bottom: 2rem;
 }
+
+/* ── DATE FILTER BAR ── */
+.date-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: var(--green-light);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    border: 1px solid #b8dfc8;
+}
+.date-filter-presets {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+.date-preset-btn {
+    padding: 0.35rem 0.85rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--green);
+    border: 1.5px solid var(--green);
+    background: transparent;
+    transition: all 0.2s;
+}
+.date-preset-btn:hover,
+.date-preset-btn.active { background: var(--green); color: #fff; }
+.date-filter-custom {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.date-filter-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+.date-filter-input {
+    padding: 0.35rem 0.6rem;
+    border: 1.5px solid var(--border);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    background: #fff;
+}
+.date-filter-submit {
+    padding: 0.35rem 1rem;
+    background: var(--green);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+.date-filter-submit:hover { background: var(--green-mid); }
+
+/* ── COMMISSION SUMMARY ── */
+.commission-summary {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+    max-width: 500px;
+}
+.commission-summary-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+}
+.commission-summary-row:last-child { border-bottom: none; }
+.commission-highlight { color: var(--green); font-weight: 700; }
+
+.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+.sort-icon { font-size: 0.7rem; opacity: 0.5; margin-left: 3px; }
 .tab-btn {
     background: none;
     border: none;
@@ -439,23 +522,29 @@
         </div>
         <div class="stat-card">
             <div class="stat-label">Orders</div>
-            <div class="stat-value">{{ orders|length }}</div>
+            <div class="stat-value">{{ all_orders|length }}</div>
         </div>
         <div class="stat-card">
             <div class="stat-label">Total Revenue</div>
             <div class="stat-value">£{{ total_revenue|floatformat:2 }}</div>
         </div>
         <div class="stat-card">
-            <div class="stat-label">Commission</div>
+            <div class="stat-label">Commission (5%)</div>
             <div class="stat-value">£{{ total_commission|floatformat:2 }}</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-label">Producer Payouts</div>
+            <div class="stat-value">£{{ total_producer_payout|floatformat:2 }}</div>
         </div>
     </div>
 
+    <!-- Date Range Filter -->
     <!-- Tabs -->
     <div class="tabs">
         <button class="tab-btn active" onclick="switchTab('users', this)">Users</button>
         <button class="tab-btn" onclick="switchTab('products', this)">Products</button>
         <button class="tab-btn" onclick="switchTab('orders', this)">Orders</button>
+        <button class="tab-btn" onclick="switchTab('commission', this)">Commission</button>
     </div>
 
     <!-- Users Tab -->
@@ -548,36 +637,85 @@
 
     <!-- Orders Tab -->
     <div id="tab-orders" class="tab-panel">
-        <div class="search-bar">
-            <input class="search-input" type="text" placeholder="Search orders by ID or status…" oninput="filterTable('orders-table', this.value)">
+        <div class="search-bar" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center;">
+            <input class="search-input" style="flex:1;min-width:200px;" type="text" id="orders-search" placeholder="Search orders by ID, customer or status…" oninput="filterOrders()">
+            <input type="date" class="date-filter-input" id="orders-date-from" onchange="filterOrders()" placeholder="From">
+            <input type="date" class="date-filter-input" id="orders-date-to" onchange="filterOrders()" placeholder="To">
+            <div class="date-filter-presets" style="display:flex;gap:0.4rem;">
+                <button type="button" class="date-preset-btn" onclick="setOrdersPreset('all')">All</button>
+                <button type="button" class="date-preset-btn" onclick="setOrdersPreset('today')">Today</button>
+                <button type="button" class="date-preset-btn" onclick="setOrdersPreset('week')">7 Days</button>
+                <button type="button" class="date-preset-btn" onclick="setOrdersPreset('month')">30 Days</button>
+            </div>
         </div>
         <table class="data-table" id="orders-table">
             <thead>
                 <tr>
-                    <th>Order ID</th>
-                    <th>Customer</th>
-                    <th>Total</th>
-                    <th>Commission</th>
-                    <th>Status</th>
-                    <th>Delivery Date</th>
-                    <th>Placed</th>
+                    <th onclick="sortTable('orders-table', 0)" class="sortable">Order ID <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 1)" class="sortable">Customer <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 2)" class="sortable">Producer <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 3)" class="sortable">Total <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 4)" class="sortable">Commission <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 5)" class="sortable">Status <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('orders-table', 6)" class="sortable">Placed <span class="sort-icon">↕</span></th>
                 </tr>
             </thead>
             <tbody>
-                {% for order in orders %}
-                <tr>
+                {% for order in all_orders %}
+                <tr data-date="{{ order.created_at|slice:':10' }}">
                     <td><strong>#{{ order.id }}</strong></td>
-                    <td>{{ order.customer }}</td>
+                    <td>{{ order.customer_username|default:order.customer }}</td>
+                    <td>{{ order.producer_name|default:"—" }}</td>
                     <td>£{{ order.total_amount }}</td>
                     <td>£{{ order.commission_total|default:"0.00" }}</td>
                     <td>
                         <span class="status-badge status-{{ order.status|lower }}">{{ order.status }}</span>
                     </td>
-                    <td>{{ order.delivery_date|default:"—" }}</td>
                     <td>{{ order.created_at|slice:":10" }}</td>
                 </tr>
                 {% empty %}
                 <tr class="empty-row"><td colspan="7">No orders found.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Commission Tab -->
+    <div id="tab-commission" class="tab-panel">
+        <div class="search-bar" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center;">
+            <input class="search-input" style="flex:1;min-width:200px;" type="text" id="commission-search" placeholder="Search by producer…" oninput="filterCommissionTable()">
+            <input type="date" class="date-filter-input" id="commission-date-from" onchange="filterCommission()">
+            <input type="date" class="date-filter-input" id="commission-date-to" onchange="filterCommission()">
+            <div class="date-filter-presets" style="display:flex;gap:0.4rem;">
+                <button type="button" class="date-preset-btn active" onclick="setCommissionPreset('all')">All</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('today')">Today</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('week')">7 Days</button>
+                <button type="button" class="date-preset-btn" onclick="setCommissionPreset('month')">30 Days</button>
+            </div>
+        </div>
+
+        <h3 style="font-family:'Cormorant Garamond',serif;font-size:1.2rem;margin:1.5rem 0 0.75rem;">Per-Producer Breakdown</h3>
+        <table class="data-table" id="commission-table">
+            <thead>
+                <tr>
+                    <th onclick="sortTable('commission-table', 0)" class="sortable">Producer <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('commission-table', 1)" class="sortable">Orders <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('commission-table', 2)" class="sortable">Total Revenue <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('commission-table', 3)" class="sortable">Commission (5%) <span class="sort-icon">↕</span></th>
+                    <th onclick="sortTable('commission-table', 4)" class="sortable">Producer Payout <span class="sort-icon">↕</span></th>
+                </tr>
+            </thead>
+            <tbody id="commission-tbody">
+                {% for row in producer_breakdown %}
+                <tr>
+                    <td><strong>{{ row.producer }}</strong></td>
+                    <td>{{ row.order_count }}</td>
+                    <td>£{{ row.total_revenue|floatformat:2 }}</td>
+                    <td>£{{ row.total_commission|floatformat:2 }}</td>
+                    <td>£{{ row.total_payout|floatformat:2 }}</td>
+                </tr>
+                {% empty %}
+                <tr class="empty-row"><td colspan="5">No commission data found.</td></tr>
                 {% endfor %}
             </tbody>
         </table>
@@ -673,6 +811,7 @@ function switchTab(name, btn) {
     document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
     document.getElementById('tab-' + name).classList.add('active');
     btn.classList.add('active');
+    if (name === 'commission') filterCommission();
 }
 
 function filterTable(tableId, query) {
@@ -680,6 +819,154 @@ function filterTable(tableId, query) {
     const rows = document.querySelectorAll('#' + tableId + ' tbody tr:not(.empty-row)');
     rows.forEach(row => {
         row.style.display = row.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+}
+
+// ── ORDERS FILTERING ──
+function filterOrders() {
+    const query = (document.getElementById('orders-search').value || '').toLowerCase();
+    const dateFrom = document.getElementById('orders-date-from').value;
+    const dateTo = document.getElementById('orders-date-to').value;
+    const rows = document.querySelectorAll('#orders-table tbody tr:not(.empty-row)');
+    rows.forEach(row => {
+        const text = row.textContent.toLowerCase();
+        const rowDate = row.getAttribute('data-date') || '';
+        const textMatch = !query || text.includes(query);
+        const fromMatch = !dateFrom || rowDate >= dateFrom;
+        const toMatch = !dateTo || rowDate <= dateTo;
+        row.style.display = (textMatch && fromMatch && toMatch) ? '' : 'none';
+    });
+}
+
+function setOrdersPreset(preset) {
+    const today = new Date().toISOString().slice(0, 10);
+    const fromInput = document.getElementById('orders-date-from');
+    const toInput = document.getElementById('orders-date-to');
+    document.querySelectorAll('#tab-orders .date-preset-btn').forEach(b => b.classList.remove('active'));
+    event.target.classList.add('active');
+    if (preset === 'all') {
+        fromInput.value = '';
+        toInput.value = '';
+    } else if (preset === 'today') {
+        fromInput.value = today;
+        toInput.value = today;
+    } else if (preset === 'week') {
+        const d = new Date(); d.setDate(d.getDate() - 7);
+        fromInput.value = d.toISOString().slice(0, 10);
+        toInput.value = today;
+    } else if (preset === 'month') {
+        const d = new Date(); d.setDate(d.getDate() - 30);
+        fromInput.value = d.toISOString().slice(0, 10);
+        toInput.value = today;
+    }
+    filterOrders();
+}
+
+// ── COMMISSION FILTERING ──
+function filterCommissionTable() {
+    const q = (document.getElementById('commission-search').value || '').toLowerCase();
+    const rows = document.querySelectorAll('#commission-table tbody tr:not(.empty-row)');
+    rows.forEach(row => {
+        row.style.display = !q || row.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+}
+
+function filterCommission() {
+    const dateFrom = document.getElementById('commission-date-from').value;
+    const dateTo = document.getElementById('commission-date-to').value;
+
+    // Filter orders table rows to calculate totals
+    const allRows = document.querySelectorAll('#orders-table tbody tr:not(.empty-row)');
+    let revenue = 0, commission = 0;
+    const producerTotals = {};
+
+    allRows.forEach(row => {
+        const rowDate = row.getAttribute('data-date') || '';
+        const fromMatch = !dateFrom || rowDate >= dateFrom;
+        const toMatch = !dateTo || rowDate <= dateTo;
+        if (fromMatch && toMatch) {
+            const cells = row.querySelectorAll('td');
+            const r = parseFloat((cells[3].textContent || '0').replace('£', '')) || 0;
+            const c = parseFloat((cells[4].textContent || '0').replace('£', '')) || 0;
+            const producer = cells[2].textContent.trim();
+            revenue += r;
+            commission += c;
+            if (!producerTotals[producer]) producerTotals[producer] = { orders: 0, revenue: 0, commission: 0 };
+            producerTotals[producer].orders++;
+            producerTotals[producer].revenue += r;
+            producerTotals[producer].commission += c;
+        }
+    });
+
+    // Update summary stats in the stat cards
+    document.getElementById('summary-revenue') && (document.getElementById('summary-revenue').textContent = '£' + revenue.toFixed(2));
+    document.getElementById('summary-commission') && (document.getElementById('summary-commission').textContent = '£' + commission.toFixed(2));
+    document.getElementById('summary-payout') && (document.getElementById('summary-payout').textContent = '£' + (revenue - commission).toFixed(2));
+
+    // Rebuild producer breakdown table
+    const tbody = document.getElementById('commission-tbody');
+    tbody.innerHTML = '';
+    const sorted = Object.entries(producerTotals).sort((a, b) => b[1].commission - a[1].commission);
+    if (sorted.length === 0) {
+        tbody.innerHTML = '<tr class="empty-row"><td colspan="5">No commission data for this period.</td></tr>';
+    } else {
+        sorted.forEach(([producer, data]) => {
+            const payout = data.revenue - data.commission;
+            tbody.innerHTML += `<tr>
+                <td><strong>${producer}</strong></td>
+                <td>${data.orders}</td>
+                <td>£${data.revenue.toFixed(2)}</td>
+                <td>£${data.commission.toFixed(2)}</td>
+                <td>£${payout.toFixed(2)}</td>
+            </tr>`;
+        });
+    }
+}
+
+function setCommissionPreset(preset) {
+    const today = new Date().toISOString().slice(0, 10);
+    const fromInput = document.getElementById('commission-date-from');
+    const toInput = document.getElementById('commission-date-to');
+    document.querySelectorAll('#tab-commission .date-preset-btn').forEach(b => b.classList.remove('active'));
+    event.target.classList.add('active');
+    if (preset === 'all') {
+        fromInput.value = '';
+        toInput.value = '';
+    } else if (preset === 'today') {
+        fromInput.value = today;
+        toInput.value = today;
+    } else if (preset === 'week') {
+        const d = new Date(); d.setDate(d.getDate() - 7);
+        fromInput.value = d.toISOString().slice(0, 10);
+        toInput.value = today;
+    } else if (preset === 'month') {
+        const d = new Date(); d.setDate(d.getDate() - 30);
+        fromInput.value = d.toISOString().slice(0, 10);
+        toInput.value = today;
+    }
+    filterCommission();
+}
+
+// ── SORTING ──
+const sortState = {};
+function sortTable(tableId, colIndex) {
+    const key = tableId + '_' + colIndex;
+    sortState[key] = !sortState[key];
+    const asc = sortState[key];
+    const tbody = document.querySelector('#' + tableId + ' tbody');
+    const rows = Array.from(tbody.querySelectorAll('tr:not(.empty-row)'));
+    rows.sort((a, b) => {
+        const aText = a.querySelectorAll('td')[colIndex]?.textContent.trim() || '';
+        const bText = b.querySelectorAll('td')[colIndex]?.textContent.trim() || '';
+        const aNum = parseFloat(aText.replace(/[£,]/g, ''));
+        const bNum = parseFloat(bText.replace(/[£,]/g, ''));
+        if (!isNaN(aNum) && !isNaN(bNum)) return asc ? aNum - bNum : bNum - aNum;
+        return asc ? aText.localeCompare(bText) : bText.localeCompare(aText);
+    });
+    rows.forEach(r => tbody.appendChild(r));
+    // Update sort icons
+    document.querySelectorAll('#' + tableId + ' .sort-icon').forEach((icon, i) => {
+        icon.textContent = i === colIndex ? (asc ? '↑' : '↓') : '↕';
     });
 }
 

--- a/services/frontend-service/web/views.py
+++ b/services/frontend-service/web/views.py
@@ -572,7 +572,7 @@ def profile_view(request):
 
 def admin_dashboard(request):
     """
-    Admin dashboard with tabs for users, products, orders, and site stats.
+    Admin dashboard with tabs for users, products, orders, and commission.
     """
     if not request.session.get('token') or request.session.get('role') != 'ADMIN':
         return redirect('/login/')
@@ -601,16 +601,34 @@ def admin_dashboard(request):
 
     total_revenue = sum(float(o.get('total_amount', 0)) for o in orders)
     total_commission = sum(float(o.get('commission_total') or 0) for o in orders)
+    total_producer_payout = total_revenue - total_commission
     customers = [u for u in users if u.get('role') == 'CUSTOMER']
     producers = [u for u in users if u.get('role') == 'PRODUCER']
+
+    # Build producer breakdown from all orders
+    producer_breakdown = {}
+    for o in orders:
+        producer = o.get('producer') or o.get('producer_name') or 'Unknown'
+        if producer not in producer_breakdown:
+            producer_breakdown[producer] = {'producer': producer, 'order_count': 0, 'total_revenue': 0.0, 'total_commission': 0.0, 'total_payout': 0.0}
+        rev = float(o.get('total_amount', 0))
+        com = float(o.get('commission_total') or 0)
+        producer_breakdown[producer]['order_count'] += 1
+        producer_breakdown[producer]['total_revenue'] += rev
+        producer_breakdown[producer]['total_commission'] += com
+        producer_breakdown[producer]['total_payout'] += (rev - com)
+
+    producer_breakdown_list = sorted(producer_breakdown.values(), key=lambda x: x['total_commission'], reverse=True)
 
     return render(request, 'web/admin.html', {
         'users': users,
         'products': products,
-        'orders': orders,
+        'all_orders': orders,
         'error': error,
         'total_revenue': total_revenue,
         'total_commission': total_commission,
+        'total_producer_payout': total_producer_payout,
+        'producer_breakdown': producer_breakdown_list,
         'customer_count': len(customers),
         'producer_count': len(producers),
         'media_base_url': MEDIA_BASE_URL,

--- a/services/frontend-service/web/views.py
+++ b/services/frontend-service/web/views.py
@@ -1,9 +1,12 @@
 import os
 import json
+import csv
+import math
 import requests
 from datetime import date, timedelta, datetime
 from urllib.parse import quote
 from django.shortcuts import render, redirect
+from django.http import HttpResponse
 
 # Base URL of the platform API service — no trailing slash, no /api suffix
 PLATFORM_API_URL = os.environ.get('PLATFORM_API_URL', 'http://platform-api:8002')
@@ -11,6 +14,38 @@ PLATFORM_API_URL = os.environ.get('PLATFORM_API_URL', 'http://platform-api:8002'
 # Used by the browser to load product images served by the platform service.
 MEDIA_BASE_URL = os.environ.get('MEDIA_BASE_URL', 'http://localhost:8002')
 PAYMENT_GATEWAY_URL = os.environ.get('PAYMENT_GATEWAY_URL', 'http://payment-gateway:8003')
+
+def _get_postcode_coords(postcode):
+    """Fetch lat/lng for a UK postcode from postcodes.io."""
+    try:
+        resp = requests.get(
+            f"https://api.postcodes.io/postcodes/{postcode.strip().replace(' ', '%20')}",
+            timeout=5
+        )
+        if resp.status_code == 200:
+            result = resp.json().get('result', {})
+            if result:
+                return result.get('latitude'), result.get('longitude')
+    except Exception:
+        pass
+    return None, None
+
+def _haversine_miles(lat1, lon1, lat2, lon2):
+    R = 3958.8
+    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
+    return R * 2 * math.asin(math.sqrt(a))
+
+def _calculate_food_miles(customer_postcode, producer_postcode):
+    if not customer_postcode or not producer_postcode:
+        return None
+    lat1, lon1 = _get_postcode_coords(customer_postcode)
+    lat2, lon2 = _get_postcode_coords(producer_postcode)
+    if None in (lat1, lon1, lat2, lon2):
+        return None
+    return round(_haversine_miles(lat1, lon1, lat2, lon2), 1)
 
 # UK 14 Major Allergens
 UK_ALLERGENS = [
@@ -633,6 +668,57 @@ def admin_dashboard(request):
         'producer_count': len(producers),
         'media_base_url': MEDIA_BASE_URL,
     })
+
+
+def admin_commission_export(request):
+    """Export commission data as CSV for accounting software."""
+    if not request.session.get('token') or request.session.get('role') != 'ADMIN':
+        return redirect('/login/')
+
+    headers = get_auth_headers(request)
+    orders = []
+
+    try:
+        resp_orders = requests.get(f"{PLATFORM_API_URL}/api/orders/", headers=headers, timeout=5)
+        if resp_orders.status_code == 200:
+            orders = resp_orders.json()
+    except Exception:
+        pass
+
+    # Apply date filters from query params
+    date_from = request.GET.get('date_from', '').strip()
+    date_to = request.GET.get('date_to', '').strip()
+    if date_from:
+        orders = [o for o in orders if (o.get('created_at') or '')[:10] >= date_from]
+    if date_to:
+        orders = [o for o in orders if (o.get('created_at') or '')[:10] <= date_to]
+
+    response = HttpResponse(content_type='text/csv')
+    filename = f"brfn_commission_{date.today()}.csv"
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+    writer = csv.writer(response)
+    writer.writerow([
+        'Order ID', 'Date', 'Customer', 'Producer', 'Status',
+        'Order Total (£)', 'Commission 5% (£)', 'Producer Payout 95% (£)'
+    ])
+
+    for o in orders:
+        total = float(o.get('total_amount', 0))
+        commission = float(o.get('commission_total') or 0)
+        payout = total - commission
+        writer.writerow([
+            f"#{o.get('id', '')}",
+            (o.get('created_at') or '')[:10],
+            o.get('customer_username') or o.get('customer', ''),
+            o.get('producer_name') or '—',
+            o.get('status', ''),
+            f"{total:.2f}",
+            f"{commission:.2f}",
+            f"{payout:.2f}",
+        ])
+
+    return response
 
 
 def admin_delete_user(request, user_id):


### PR DESCRIPTION
## Commission Monitoring & Reporting — TC-025

### Overview
Implements a comprehensive commission monitoring and reporting system for the network administrator, satisfying TC-025. The 5% network commission is automatically calculated on every order and fully reportable through the admin dashboard.

### Closes
- Satisfies TC-025 — Network commission monitoring and financial reporting
- Relates to #22 — Automated commission logic

---

### How Commission Works
- Every order placed automatically calculates a **5% network commission**
- The remaining **95% is the producer payout**
- In multi-vendor orders, commission is calculated per producer order (5% of each producer's subtotal)
- All values are stored to 2 decimal places

### Example
- Order total £100 → Commission £5.00, Producer payout £95.00
- Multi-vendor order £150 (Producer A £80, Producer B £70) → Total commission £7.50, Producer A payout £76.00, Producer B payout £66.50

---

### Changes Made

#### Platform API
- `orders/serializers.py` — added `commission_total` to `OrderSerializer` fields and `read_only_fields`, added `CustomerOrderSerializer`, updated `customer_full_name` to `customer_first_name`/`customer_last_name`

#### Frontend
- `web/views.py` — updated `admin_dashboard` view with per-producer commission breakdown, added `admin_commission_export` view for CSV download
- `web/templates/web/admin.html` — full commission tab redesign with:
  - Search by producer
  - Filter by order status (Pending/Confirmed/Ready/Delivered)
  - Date range filter with presets (Today, 7 Days, This Month, YTD, All Time, custom)
  - Period summary cards (orders count, total revenue, commission, producer payouts)
  - Monthly summary table grouped by calendar month
  - Per-producer breakdown table with sortable columns
  - CSV export button
- `frontend/urls.py` — added `/admin-dashboard/commission/export/` route

---

### Screenshots

**Commission tab overview**
<img width="1888" height="1038" alt="image" src="https://github.com/user-attachments/assets/ecd5bc85-4ea3-4614-8b21-fc1f7b843c11" />

**Monthly summary**
<img width="929" height="124" alt="image" src="https://github.com/user-attachments/assets/0ae04002-85cb-40d3-b25c-076f9eeec2b3" />

**Per-producer breakdown**
<img width="960" height="135" alt="image" src="https://github.com/user-attachments/assets/30821b27-887c-4429-b488-156ee275cc2c" />

**CSV export**
<img width="926" height="88" alt="image" src="https://github.com/user-attachments/assets/e830a14b-4ae9-4235-9f98-e4045863f207" />
---

### Testing
1. Log in as admin and navigate to `/admin-dashboard/`
2. Click the **Commission** tab
3. Verify period summary cards show correct totals matching the stat cards above
4. Use date presets (YTD, This Month, 7 Days) — summary and tables should update instantly
5. Use the status filter to filter by PENDING/CONFIRMED etc
6. Search by producer name in the search bar
7. Click **Export CSV** — a CSV file should download with order-level commission data
8. Verify the monthly summary groups orders correctly by month
9. Verify per-producer breakdown shows correct 5% commission and 95% payout per producer

### Calculation Verification
After seeding, place a test order and verify:
- `commission_total` = `total_amount × 0.05`
- Producer payout = `total_amount × 0.95`
- Values accurate to 2 decimal places